### PR TITLE
Fix JSESSIONID regexp

### DIFF
--- a/src/WebServices.php
+++ b/src/WebServices.php
@@ -314,7 +314,7 @@ class WebServices
 
             // Get and save session id
             $matches = [];
-            if (preg_match("#JSESSIONID=([a-z0-9.]+)#i", $this->soapClient->__getLastResponseHeaders(), $matches) == 1) {
+            if (preg_match("#JSESSIONID=([-a-z0-9.]+)#i", $this->soapClient->__getLastResponseHeaders(), $matches) == 1) {
                 if ($matches[1] != $this->soapSessionId) {
                     $this->soapSessionId = $matches[1];
                     $this->soapClient->__setCookie('JSESSIONID', $this->soapSessionId);


### PR DESCRIPTION
The cookie value may contain a dash `-` character

Example from their "TEST" environnement :
```
Date: Mon, 14 Mar 2022 16:01:58 GMT
Server: Apache
Set-Cookie: JSESSIONID=AfCC37d87A6c5dBEe5d3C467F4F6dabD19eDbEa1.vadpayment01-bdx-prod-fr-lyra; path=/vads-ws
X-Lyra-SID: e67e5f9763e1491bad3c8b7b3c34a7de
Content-Length: 1993
Vary: Accept-Encoding,User-Agent
Timing-Allow-Origin: *
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
Content-Type: text/xml;charset=UTF-8
```